### PR TITLE
update multiprocessing & caption paraphrase

### DIFF
--- a/common/args.py
+++ b/common/args.py
@@ -20,6 +20,19 @@ class DataArgs:
     vqa_output_dir: str = field(default="results")
     stage: int = field(default=1)
     num_basic_geo_samples: int = field(default=100000)
+    # set num_samples for each num_shapes
+    # key: num_shapes, value: num_samples
+    num_samples_per_num_shapes: dict[int, int] = field(
+        default_factory=lambda: {
+            2: 10,
+            3: 10,
+            4: 10,
+            5: 10,
+            6: 10,
+            7: 10,
+            8: 10,
+        }
+    )
     num_fossil_samples: int = field(default=3)
     llava_data_dir: str = field(default="dataset/llava")
 

--- a/common/args.py
+++ b/common/args.py
@@ -19,20 +19,9 @@ class DataArgs:
     vqa_question_dir: str = field(default="dataset/vqa")
     vqa_output_dir: str = field(default="results")
     stage: int = field(default=1)
-    num_basic_geo_samples: int = field(default=100000)
     # set num_samples for each num_shapes
-    # key: num_shapes, value: num_samples
-    num_samples_per_num_shapes: dict[int, int] = field(
-        default_factory=lambda: {
-            2: 10,
-            3: 10,
-            4: 10,
-            5: 10,
-            6: 10,
-            7: 10,
-            8: 10,
-        }
-    )
+    # num_samples_per_num_shapes[i]: number of samples for num_shapes=(min_num_shapes + i)
+    num_samples_per_num_shapes: list[int] = field(default_factory=lambda: [10, 10, 10])
     num_fossil_samples: int = field(default=3)
     llava_data_dir: str = field(default="dataset/llava")
 
@@ -59,9 +48,7 @@ class RuleArgs:
     output_fp_precision: int = field(default=4)
 
     """args for stage 1"""
-    max_num_shapes: int = field(default=10)
     min_num_shapes: int = field(default=2)
-
     in_canvas_area_thres: float = field(default=0.8)
     # levels of shape generation
     polygon_shape_level: int = field(default=5)

--- a/data/caption/paraphrase.py
+++ b/data/caption/paraphrase.py
@@ -1,0 +1,79 @@
+import os
+import json
+
+from tqdm import tqdm
+
+from common.args import caption_args, data_args
+from common.llm import generator_mapping, model_path_mapping
+
+
+class Paraphraser:
+    def __init__(self) -> None:
+        self.loaded_llm = False
+
+    def load_llm_generator(self):
+        """Initialize the LLM generator for paraphrasing"""
+        assert not self.loaded_llm
+        # Initialize llm
+        model_name, model_id = caption_args.caption_llm.split("-", 1)
+        model_path = model_path_mapping[model_name].format(model_id)
+        self.llm_generator = generator_mapping[model_name](model_path)
+        self.loaded_llm = True
+
+        # Initialize prompt
+        self.sys_prompt = "You are a helpful assistant skilled in text paraphrasing."
+        with open("data/caption/paraphrase_prompt.txt", "r") as f:
+            self.user_prompt = f.read()
+
+    def _generate_paraphrase_prompt(self, texts: list[str]) -> list[list[dict[str, str]]]:
+        """Generate the prompt for paraphrasing"""
+        user_prompts = [f"{self.user_prompt.replace('{text}', text)}" for text in texts]
+
+        messages = [
+            [
+                {"role": "system", "content": self.sys_prompt},
+                {"role": "user", "content": user_prompt},
+            ]
+            for user_prompt in user_prompts
+        ]
+        return messages
+
+    def __call__(self, texts: list[str]) -> list[str]:
+        """Paraphrase a single text input"""
+        if not self.loaded_llm:
+            self.load_llm_generator()
+
+        output = []
+        messages = self._generate_paraphrase_prompt(texts)
+        responses = self.llm_generator(messages, batch_size=min(len(texts), caption_args.caption_batchsize))
+
+        outputs = []
+        total_batches = (len(messages) + caption_args.caption_batchsize - 1) // caption_args.caption_batchsize
+        for batch in tqdm(responses, total=total_batches, desc="Paraphrasing"):
+            outputs.extend(batch)
+
+        return output
+
+
+def main():
+    paraphraser = Paraphraser()
+    # Read original captions
+    with open(data_args.caption_path, "r") as f:
+        captions = [json.loads(line) for line in f]
+
+    # Extract and paraphrase outputs
+    original_outputs = [caption["output"] for caption in captions]
+    paraphrased_outputs = paraphraser(original_outputs)
+
+    # Replace original outputs with paraphrased ones
+    for caption, paraphrased_output in zip(captions, paraphrased_outputs):
+        caption["output"] = paraphrased_output
+
+    output_path = data_args.caption_path
+    with open(output_path, "w") as f:
+        for caption in captions:
+            f.write(json.dumps(caption) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/data/caption/paraphrase_prompt.txt
+++ b/data/caption/paraphrase_prompt.txt
@@ -1,0 +1,14 @@
+Task:
+Please paraphrase the following text.
+
+Requirements:
+1. Paraphrase the translated/English text while maintaining:
+   - The original scientific tone and accuracy
+   - All numerical values and units
+   - The logical structure and key concepts
+2. If the input text is not in English, first translate it to English while preserving numerical values
+
+Input text:
+{text}
+
+Paraphrased text:

--- a/data/rule/generate.py
+++ b/data/rule/generate.py
@@ -196,10 +196,14 @@ def process_single(f, idx_sample: tuple[int, dict], vars):
 
 def generate_rules_multiprocess(num_workers: int = 2) -> list[dict[str, list]]:
     """Multiprocessing version"""
-    target_samples_list = []
 
-    base_samples = {k: v // num_workers for k, v in data_args.num_samples_per_num_shapes.items()}
-    remainder_samples = {k: v % num_workers for k, v in data_args.num_samples_per_num_shapes.items()}
+    target_num_samples = {}
+    for i, num_samples in enumerate(data_args.num_samples_per_num_shapes):
+        target_num_samples[i + rule_args.min_num_shapes] = num_samples
+
+    target_samples_list = []
+    base_samples = {k: v // num_workers for k, v in target_num_samples.items()}
+    remainder_samples = {k: v % num_workers for k, v in target_num_samples.items()}
 
     # Create target samples for all workers except last
     for _ in range(num_workers - 1):
@@ -231,7 +235,10 @@ def save_rules(rules: list[dict[str, list]], output_file: str):
 def main():
     if data_args.stage == 1:
         if run_args.num_workers == 1:
-            samples = generate_rules(data_args.num_samples_per_num_shapes)
+            target_num_samples = {}
+            for i, num_samples in enumerate(data_args.num_samples_per_num_shapes):
+                target_num_samples[i + rule_args.min_num_shapes] = num_samples
+            samples = generate_rules(target_num_samples)
         else:
             samples = generate_rules_multiprocess(run_args.num_workers)
     elif data_args.stage == 2:

--- a/data/rule/generate.py
+++ b/data/rule/generate.py
@@ -2,11 +2,13 @@
 import json
 import os
 
+from multiprocessing import Pool
 import numpy as np
 from numpy.random import choice, normal, randint
 from tqdm import tqdm, trange
 
-from common.args import data_args, rule_args
+from common.args import data_args, rule_args, run_args
+from iterwrap import iterate_wrapper
 from data.rule.relations import (
     CustomedShapeGenerator,
     EllipseRelationGenerator,
@@ -15,10 +17,10 @@ from data.rule.relations import (
     SeptaGenerator,
 )
 from data.rule.shapes import ShapeGenerator
-from data.rule.utils import overlap_area, round_floats
+from data.rule.utils import overlap_area, no_overlap, round_floats
 
 
-def generate_fossil_rules(data_args, rule_args) -> list[dict[str, list]]:
+def generate_fossil_rules() -> list[dict[str, list]]:
     shape_generator = ShapeGenerator(rule_args)
     results = []
 
@@ -112,27 +114,32 @@ def generate_fossil_rules(data_args, rule_args) -> list[dict[str, list]]:
     return results
 
 
-def generate_rules(data_args, rule_args) -> list[dict[str, list]]:
+def generate_rules(target_num_samples: dict[int, int]) -> list[dict[str, list]]:
     """
     Generate random rules across different types and shapes. Then mix them together.
-    Returns: a list of samples where each consists a list of shapes and a list of relations.
+    Input:
+    target_num_samples (dict): Dictionary of expected number of samples where:
+        * Key (int): num_shapes
+        * Value (int): num_samples
+    Returns:
+    a list of samples where each consists a list of shapes and a list of relations.
     """
+    results = []
     shape_generator = ShapeGenerator(rule_args)
     relation_generator = RelationGenerator(rule_args)
-    results = []
 
-    num_init_shapes = 0
-    total_shapes = 0
-    progress_bar = tqdm(total=data_args.num_basic_geo_samples, desc="Generating rules")
-    while len(results) < data_args.num_basic_geo_samples:
+    max_num_shapes = max([key for key in target_num_samples])
+    progress_bar = tqdm(total=sum(target_num_samples.values()), desc="Generating rules")
+    cur_num_samples = {k: 0 for k in target_num_samples.keys()}
+
+    # Generate samples until reaching the target number of samples for each shape count
+    while not all(cur_num_samples.get(k, 0) >= v for k, v in target_num_samples.items()):
         shapes = []
-        num_shapes = randint(1, rule_args.max_num_shapes // 2 + 1)  # leave space for special relations
+        num_shapes = randint(1, max_num_shapes // 2 + 1)  # leave space for special relations
         for _ in range(num_shapes):
             new_shape = shape_generator()
             if no_overlap(shapes, new_shape):
                 shapes.append(new_shape)
-
-        num_init_shapes = num_init_shapes + len(shapes)
 
         relations = []
         for head_idx in range(len(shapes)):
@@ -153,8 +160,8 @@ def generate_rules(data_args, rule_args) -> list[dict[str, list]]:
                     if area_in_canvas / area_tail_bbox < rule_args.in_canvas_area_thres:
                         continue
 
-                    if len(shapes) >= rule_args.max_num_shapes:
-                        break
+                    # if len(shapes) >= rule_args.max_num_shapes:
+                    #     break
 
                     # Add each tail_shape to shapes
                     tail_idx = len(shapes)
@@ -171,41 +178,49 @@ def generate_rules(data_args, rule_args) -> list[dict[str, list]]:
                     shapes.append(t_shape)
                     exclude_shape.append(t_shape)
 
-        total_shapes += len(shapes)
-
-        if len(shapes) >= rule_args.min_num_shapes:
+        if cur_num_samples.get(len(shapes), 0) < target_num_samples.get(len(shapes), 0):
             shapes_dict = [shape.to_dict() for shape in shapes]
             sample = {"shapes": shapes_dict, "relations": relations}
+            cur_num_samples[len(shapes)] += 1
             results.append(sample)
             progress_bar.update(1)
 
-    # print(f"number of initial shapes = {num_init_shapes}")
-    # print(f"total shapes = {total_shapes}")
-    # assert len(results) == data_args.num_basic_geo_samples
     return results
 
 
-def no_overlap(shapes, new_shape, exclude_shape=None, thres=0.2) -> bool:
-    if new_shape is None:
-        return False
+def process_single(f, idx_sample: tuple[int, dict], vars):
+    target_num_samples = idx_sample[1]
+    results = generate_rules(target_num_samples)
+    return results
 
-    if exclude_shape is None:
-        exclude_shape = []
 
-    iou_sum = 0
-    for cur_shape in shapes:
-        if cur_shape not in exclude_shape:
-            cur_bbox = cur_shape.get_bbox()
-            new_bbox = new_shape.get_bbox()
-            cur_area = (cur_bbox[1][0] - cur_bbox[0][0]) * (cur_bbox[0][1] - cur_bbox[1][1])
-            new_area = (new_bbox[1][0] - new_bbox[0][0]) * (new_bbox[0][1] - new_bbox[1][1])
-            intersection = overlap_area(cur_bbox, new_bbox)
-            union = cur_area + new_area - intersection
-            iou_sum += intersection / union
+def generate_rules_multiprocess(num_workers: int = 2) -> list[dict[str, list]]:
+    """Multiprocessing version"""
+    target_samples_list = []
 
-    if iou_sum > thres:
-        return False
-    return True
+    base_samples = {k: v // num_workers for k, v in data_args.num_samples_per_num_shapes.items()}
+    remainder_samples = {k: v % num_workers for k, v in data_args.num_samples_per_num_shapes.items()}
+
+    # Create target samples for all workers except last
+    for _ in range(num_workers - 1):
+        target_samples_list.append(base_samples.copy())
+
+    # Create last target sample with base + remainders
+    last_sample = base_samples.copy()
+    for k, v in remainder_samples.items():
+        last_sample[k] += v
+    target_samples_list.append(last_sample)
+
+    results_list = iterate_wrapper(
+        process_single,
+        list(enumerate(target_samples_list)),
+        num_workers=num_workers,
+        run_name="generate_rules",
+        bar=run_args.progress_bar,
+    )
+    # Flatten the list of lists into a single list
+    results = [item for sublist in results_list for item in sublist]
+    return results
 
 
 def save_rules(rules: list[dict[str, list]], output_file: str):
@@ -215,9 +230,12 @@ def save_rules(rules: list[dict[str, list]], output_file: str):
 
 def main():
     if data_args.stage == 1:
-        samples = generate_rules(data_args, rule_args)
+        if run_args.num_workers == 1:
+            samples = generate_rules(data_args.num_samples_per_num_shapes)
+        else:
+            samples = generate_rules_multiprocess(run_args.num_workers)
     elif data_args.stage == 2:
-        samples = generate_fossil_rules(data_args, rule_args)
+        samples = generate_fossil_rules()
 
     os.makedirs(os.path.dirname(data_args.rules_path), exist_ok=True)
     save_rules(samples, data_args.rules_path)

--- a/data/rule/utils.py
+++ b/data/rule/utils.py
@@ -186,6 +186,29 @@ def overlap_area(bbox1, bbox2) -> float:
     return overlap_area
 
 
+def no_overlap(shapes, new_shape, exclude_shape=None, thres=0.2) -> bool:
+    if new_shape is None:
+        return False
+
+    if exclude_shape is None:
+        exclude_shape = []
+
+    iou_sum = 0
+    for cur_shape in shapes:
+        if cur_shape not in exclude_shape:
+            cur_bbox = cur_shape.get_bbox()
+            new_bbox = new_shape.get_bbox()
+            cur_area = (cur_bbox[1][0] - cur_bbox[0][0]) * (cur_bbox[0][1] - cur_bbox[1][1])
+            new_area = (new_bbox[1][0] - new_bbox[0][0]) * (new_bbox[0][1] - new_bbox[1][1])
+            intersection = overlap_area(cur_bbox, new_bbox)
+            union = cur_area + new_area - intersection
+            iou_sum += intersection / union
+
+    if iou_sum > thres:
+        return False
+    return True
+
+
 def get_tangent_line(
     tangent_point: tuple[float, float], curve_points: list[tuple[float, float]]
 ) -> tuple[float, float]:

--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ python run.py --module data.format --action to_llava  # you can also specify the
 Running the following command can generate rules for geometric shapes in `dataset/rules.json`:
 
 ```shell
-python run.py --module data.rule.generate --stage 1 --num_basic_geo_samples 10
+python run.py --module data.rule.generate --stage 1 --num_workers 2
 ```
 
 or generate rules for synthetic fossil samples:
@@ -54,8 +54,8 @@ Each data sample contains two parts:
 
 You can control the generation process with the following arguments:
 
-- max_num_shapes: the maximum number of shapes in each sample. Default is 10
-- min_num_shapes: the minimum number of shapes in each sample. Default is 2
+- num_samples_per_num_shapes: a dictionary for setting `num_samples` for each `num_shapes`.
+NOTE: Please set the value in `args.py/DataArgs`
 
 there are some arguments for controling the numerical characteristics of geometric shapes:
 - in_canvas_area_thres: the area threshold for shapes in the canvas, between 0 and 1. A value of 1 means the entire shape has to be fully contained within the canvas. Default is 0.8

--- a/readme.md
+++ b/readme.md
@@ -54,8 +54,8 @@ Each data sample contains two parts:
 
 You can control the generation process with the following arguments:
 
-- num_samples_per_num_shapes: a dictionary for setting `num_samples` for each `num_shapes`.
-NOTE: Please set the value in `args.py/DataArgs`
+- min_num_shapes: the minimum number of shapes in each sample. Default is 2
+- num_samples_per_num_shapes: a list for setting `num_samples` for each `num_shapes`. The number of samples with `num_shapes=min_num_shapes + i` is `num_samples_per_num_shapes[i]`.
 
 there are some arguments for controling the numerical characteristics of geometric shapes:
 - in_canvas_area_thres: the area threshold for shapes in the canvas, between 0 and 1. A value of 1 means the entire shape has to be fully contained within the canvas. Default is 0.8


### PR DESCRIPTION
- generate rules添加多进程，args里更新了一个字典参数`num_samples_per_num_shapes`，用于指定有`num_shapes`个形状的样本数`num_samples`。目前在命令行控制似乎有点问题，暂时只能在args.py里改 :(
- caption里新增paraphrase，读`data_args.caption_path`指向的文件，其中output部分由caption_llm进行重写