### PR TITLE
支持jsonl文件提供参考初房中心；更新专家工具答案抽取

### DIFF
--- a/eval/eval_vis_tools.py
+++ b/eval/eval_vis_tools.py
@@ -1,3 +1,4 @@
+import argparse
 import json
 import os
 from typing import Any
@@ -6,13 +7,15 @@ import cv2
 import numpy as np
 from tqdm import tqdm
 
-from common.args import feat_recog_args, fossil_eval_args, logger
+from common.args import logger
+from stage3.get_angles_and_slope import get_angles_and_slope
 from stage3.recognize import recognize_feature
+from stage3.utils import get_circle_points
 
 
 class VisToolOutputGenerator:
-    def __init__(self) -> None:
-        self.image_path_root = os.path.join(feat_recog_args.fossil_data_path, "filtered_images")
+    def __init__(self, image_dir: str) -> None:
+        self.image_path_root = image_dir
         self.all_images = os.listdir(self.image_path_root)
         self.loaded_llm = False
 
@@ -23,7 +26,6 @@ class VisToolOutputGenerator:
             images = info["images"]
             for image_dict in images:
                 section_type = image_dict["section_type"]
-                specimen_type = image_dict["specimen_type"]
                 pixel_mm = image_dict["pixel/mm"]
                 if (
                     "axial" in section_type.lower()
@@ -61,16 +63,87 @@ class VisToolOutputGenerator:
             print(image_info)
         new_image_info["ratio"] = new_image_info["length"] / new_image_info["width"]
 
+        # Classify size by length
+        if new_image_info["length"] < 1:
+            new_image_info["size"] = "minute"
+        elif new_image_info["length"] < 3:
+            new_image_info["size"] = "small"
+        elif new_image_info["length"] < 6:
+            new_image_info["size"] = "medium"
+        elif new_image_info["length"] < 10:
+            new_image_info["size"] = "large"
+        elif new_image_info["length"] < 20:
+            new_image_info["size"] = "mega"
+        else:
+            new_image_info["size"] = "gigantic"
+
+        # Get equator, slope and poles
+        angles_and_scores = get_angles_and_slope(img_path)
+        left_angle, right_angle, upper_angle, lower_angle = angles_and_scores[:4]
+        equator_angle = (upper_angle + lower_angle) / 2
+        if equator_angle < 2.95:
+            equator = "convex"
+        elif equator_angle < 3.15:
+            equator = "straight"
+        else:
+            equator = "concave"
+        new_image_info["equator"] = equator
+
+        poles_angle = (left_angle + right_angle) / 2
+        if poles_angle < 2.35:
+            poles = "pointed"
+        else:
+            poles = "blunted"
+        new_image_info["poles"] = poles
+
+        slopes_score = np.sum(angles_and_scores[4:])
+        if slopes_score < -2.3:
+            slopes = "convex"
+        elif slopes_score < -0.8:
+            slopes = "straight"
+        else:
+            slopes = "concave"
+        new_image_info["lateral_slopes"] = slopes
+
+        shape_type = "ellipsoidal" if slopes == "convex" else "fusiform"
+        ellipsoidal_classes = {
+            "prolate spherical": [0.9, 0.98],
+            "spherical": [0.98, 1.05],
+            "sub-spherical": [1.05, 1.11],
+            "ellipsoidal": [1.11, 3],
+            "elongate ellipsoidal": [3, 6],
+            "cylindrical": [6, 999],
+        }
+        fusiform_classes = {
+            "lentoid": [0, 0.75],
+            "rhombus": [0.75, 1.3],
+            "inflated fusiform": [1.3, 1.9],
+            "fusiform": [1.9, 3.5],
+            "elongate fusiform": [3.5, 999],
+        }
+        ratio2shape = ellipsoidal_classes if shape_type == "ellipsoidal" else fusiform_classes
+        for shape, ratio_range in ratio2shape.items():
+            if ratio_range[0] < new_image_info["ratio"] <= ratio_range[1]:
+                new_image_info["shape"] = shape
+                break
+
         # Recognize fossil features
         volutions_dict, thickness_dict, initial_chamber, tunnel_angles = recognize_feature(img_path)
 
         # Process numerical info
-        has_positive = any(k > 0 for k in volutions_dict.keys())
-        has_negative = any(k < 0 for k in volutions_dict.keys())
-        if has_positive and has_negative:
-            new_image_info["num_volutions"] = len(volutions_dict) / 2
+        num_positive_keys = len([k for k in volutions_dict.keys() if k > 0])
+        num_negative_keys = len([k for k in volutions_dict.keys() if k < 0])
+        larger_key, smaller_key = max(num_positive_keys, num_negative_keys), min(
+            num_positive_keys, num_negative_keys
+        )
+        if larger_key > smaller_key + 1:
+            new_image_info["num_volutions"] = larger_key
+            if num_positive_keys > num_negative_keys:
+                volutions_dict = {k: v for k, v in volutions_dict.items() if k > 0}
+            else:
+                volutions_dict = {k: v for k, v in volutions_dict.items() if k < 0}
         else:
-            new_image_info["num_volutions"] = len(volutions_dict)
+            new_image_info["num_volutions"] = (num_positive_keys + num_negative_keys) / 2
 
         # Calculate average height between adjacent volutions
         volution_heights = {}
@@ -79,16 +152,24 @@ class VisToolOutputGenerator:
                 next_points = volutions_dict[idx - 1]
             elif idx < 0 and idx + 1 in volutions_dict:
                 next_points = volutions_dict[idx + 1]
+            elif idx == 1 and initial_chamber is not None:
+                initial_chamber_upper = get_circle_points(
+                    center=initial_chamber[:2], radius=initial_chamber[2] // 2, angle_range=[225, 315]
+                )
+                next_points = initial_chamber_upper
+            elif idx == -1 and initial_chamber is not None:
+                initial_chamber_lower = get_circle_points(
+                    center=initial_chamber[:2], radius=initial_chamber[2] // 2, angle_range=[45, 135]
+                )
+                next_points = initial_chamber_lower
             else:
                 continue
             y_mean = np.mean([point[1] for point in points])
             next_y_mean = np.mean([point[1] for point in next_points])
-            if abs(idx) - 1 not in volution_heights:
-                volution_heights[abs(idx) - 1] = abs(y_mean - next_y_mean)
+            if abs(idx) not in volution_heights:
+                volution_heights[abs(idx)] = abs(y_mean - next_y_mean)
             else:
-                volution_heights[abs(idx) - 1] = (
-                    volution_heights[abs(idx) - 1] + abs(y_mean - next_y_mean)
-                ) / 2
+                volution_heights[abs(idx)] = (volution_heights[abs(idx)] + abs(y_mean - next_y_mean)) / 2
         # Sort volution_heights by key in ascending order
         volution_heights = dict(sorted(volution_heights.items(), key=lambda item: item[0]))
         new_image_info["volution_heights"] = volution_heights
@@ -110,49 +191,77 @@ class VisToolOutputGenerator:
             new_image_info["size_init_chamber"] = initial_chamber[2] * image_info["pixel_mm"] * 1000
 
         if tunnel_angles:
+            tunnel_angles = self.post_process_tunnel_angles(
+                tunnel_angles, int(new_image_info["num_volutions"])
+            )
             new_image_info["tunnel_angles"] = tunnel_angles
+            new_image_info["tunnel_angle"] = int(sum(tunnel_angles.values()) / len(tunnel_angles))
 
         return new_image_info
 
+    def post_process_tunnel_angles(
+        self, tunnel_angles: dict[int, int], num_volutions: int, low_thres: int = 15, high_thres: int = 55
+    ) -> dict[int, int]:
+        for i in range(1, num_volutions + 1):
+            if i not in tunnel_angles:
+                tunnel_angles[i] = 25
 
-def generate_vis_tools_output():
+        in_range_angles = [angle for angle in tunnel_angles.values() if low_thres < angle < high_thres]
+        avg_angles = int(sum(in_range_angles) / len(in_range_angles)) if in_range_angles else 25
+        for i, angle in tunnel_angles.items():
+            if angle < low_thres or angle > high_thres:
+                tunnel_angles[i] = avg_angles
+
+        tunnel_angles = dict(sorted(tunnel_angles.items(), key=lambda x: x[0]))
+        min_angle = min(tunnel_angles.values())
+        max_angle = max(tunnel_angles.values())
+        total_volutions = max(tunnel_angles.keys())
+
+        if max_angle > min_angle and total_volutions > 1:
+            avg_increase = (max_angle - min_angle) / (total_volutions - 1)
+            base_angle = min(tunnel_angles.values())
+            for i in tunnel_angles.keys():
+                expected_angle = base_angle + (i - 1) * avg_increase
+                tunnel_angles[i] = int(0.5 * tunnel_angles[i] + 0.5 * expected_angle)
+
+        return tunnel_angles
+
+
+def generate_vis_tools_output(image_info_json: str, image_dir: str, output_path: str):
     # Create a data generator instance
-    evaluator = VisToolOutputGenerator()
+    evaluator = VisToolOutputGenerator(image_dir)
 
     # Load data from a JSON file containing fossil information
-    data_path = os.path.join(feat_recog_args.fossil_data_path, "filtered_data.json")
-    with open(data_path, "r") as f:
+    with open(image_info_json, "r") as f:
         data_dict = json.load(f)
 
     evaluator.extract_valid_images(data_dict)
 
-    img_2_pixel_mm = {image_info["image"]: image_info["pixel_mm"] for image_info in evaluator.images}
-
-    # Load test image files
-    test_image_path = "dataset/instructions_no_vis_tools/instructions_test.jsonl"
-    with open(test_image_path, "r") as f:
-        test_images = [json.loads(line)["image"] for line in f]
-
     # Process each image and extract required information
     output_info = []
     logger.info("Processing images and extracting information")
-    for image in tqdm(test_images):
+    for image_info in tqdm(evaluator.images):
         # Recognize features from the image
-        image_info = {"image": image, "pixel_mm": img_2_pixel_mm[image]}
         processed_info = evaluator.recognize_features(image_info)
 
         # Create a dictionary with the required fields
         fossil_info = {
-            "image_path": image,
-            "overall_size": "",
-            "overall_shape": "",
+            "image_path": image_info["image"],
+            "size": processed_info.get("size", ""),
+            "shape": processed_info.get("shape", ""),
+            "equator": processed_info.get("equator", ""),
+            "lateral_slopes": processed_info.get("lateral_slopes", ""),
+            "poles": processed_info.get("poles", ""),
             "length": f"{processed_info['length']:.3f} mm",
             "width": f"{processed_info['width']:.3f} mm",
             "ratio": f"{processed_info['ratio']:.3f}",
+            # keep axis_shape as empty string if not explicitly inferred
             "axis_shape": "",
-            "number_of_volutions": f"{processed_info['num_volutions']}",
-            "thickness_of_spirotheca": f"",
+            "number_of_volutions": f"{processed_info.get('num_volutions', '')}",
+            "coil_tightness": "",
             "height_of_volution": "",
+            "thickness_of_spirotheca": "",
+            "septa": "",
             "proloculus": "",
             "tunnel_angles": "",
             "tunnel_shape": "",
@@ -162,11 +271,14 @@ def generate_vis_tools_output():
 
         # Process thickness of spirotheca
         if "thickness_per_vol" in processed_info:
+            avg_thickness_microns = int(processed_info["avg_thickness"] * processed_info["pixel_mm"] * 1000)
             thickness_microns = [
                 str(int(thickness * processed_info["pixel_mm"] * 1000))
                 for thickness in processed_info["thickness_per_vol"].values()
             ]
-            fossil_info["thickness_of_spirotheca"] = ", ".join(thickness_microns) + " microns"
+            fossil_info["thickness_of_spirotheca"] = (
+                f"average: {avg_thickness_microns} microns; by volutions: {', '.join(thickness_microns)} microns"
+            )
 
         # Process heights of volutions
         if "volution_heights" in processed_info:
@@ -183,23 +295,48 @@ def generate_vis_tools_output():
         # Process tunnel angles
         if "tunnel_angles" in processed_info:
             angles = []
-            for i, angle in processed_info["tunnel_angles"].items():
+            for _, angle in processed_info["tunnel_angles"].items():
                 angles.append(str(angle))
-            fossil_info["tunnel_angles"] = ", ".join(angles) + " degrees"
+            if "tunnel_angle" in processed_info:
+                fossil_info["tunnel_angles"] = (
+                    f"average: {processed_info['tunnel_angle']} degrees; by volutions: "
+                    + ", ".join(angles)
+                    + " degrees"
+                )
+            else:
+                fossil_info["tunnel_angles"] = ", ".join(angles) + " degrees"
 
         output_info.append(fossil_info)
 
     # Save the extracted information to a JSON file
-    output_dir = os.path.join(fossil_eval_args.eval_result_dir, "extracted_output_info.json")
-    os.makedirs(os.path.dirname(output_dir), exist_ok=True)
-    with open(output_dir, "w") as f:
+    output_dir = os.path.dirname(output_path)
+    if output_dir:
+        os.makedirs(output_dir, exist_ok=True)
+    with open(output_path, "w") as f:
         json.dump(output_info, f, indent=4)
 
-    logger.info(f"Extracted information saved to {output_dir}")
+    logger.info(f"Extracted information saved to {output_path}")
 
 
 def main():
-    generate_vis_tools_output()
+    parser = argparse.ArgumentParser(description="Generate visual tools extraction output.")
+    parser.add_argument(
+        "--image_info_json",
+        type=str,
+        default="dataset/common/filtered_data.json",
+        help="JSON file containing image information.",
+    )
+    parser.add_argument(
+        "--image_dir", type=str, default="dataset/common/filtered_images", help="Directory containing images."
+    )
+    parser.add_argument(
+        "--output_path", type=str, default="./extracted_tool_results.json", help="Output JSON path."
+    )
+    args = parser.parse_args()
+
+    generate_vis_tools_output(
+        image_info_json=args.image_info_json, image_dir=args.image_dir, output_path=args.output_path
+    )
     # eval_vis_tools()
 
 

--- a/stage3/initial_chamber.py
+++ b/stage3/initial_chamber.py
@@ -1,3 +1,6 @@
+import json
+import os
+
 import cv2
 import matplotlib.pyplot as plt
 import numpy as np
@@ -7,8 +10,26 @@ from stage3.utils import circle_weight_array
 
 
 class ProloculusDetector:
-    def __init__(self, block_num: int = 3):
+    def __init__(self, block_num: int = 3, center_prior_jsonl: str | None = None):
         self.block_num = block_num
+        self.center_prior_dict = self._load_center_priors(center_prior_jsonl)
+
+    def _load_center_priors(self, center_prior_jsonl: str | None) -> dict[str, tuple[int, int]]:
+        if center_prior_jsonl is None:
+            return {}
+
+        center_prior_dict = {}
+        with open(center_prior_jsonl, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                parsed = json.loads(line)
+                for image_name, center in parsed.items():
+                    if isinstance(center, dict) and "x" in center and "y" in center:
+                        center_prior_dict[str(image_name)] = (int(center["x"]), int(center["y"]))
+
+        return center_prior_dict
 
     def find_center(self, window_size: int, threshold: float = 0.25):
         # Find center of proloculus using sliding window
@@ -48,13 +69,20 @@ class ProloculusDetector:
         return candidate_centers
 
     def detect_initial_chamber(
-        self, image_path_to_detect: str, threshold: float = 0.25, visualize_result: bool = False
+        self,
+        image_path_to_detect: str,
+        threshold: float = 0.25,
+        visualize_result: bool = False,
+        rough_center: tuple[int, int] | None = None,
     ):
         self.img = cv2.imread(image_path_to_detect)
         self.width, self.height = self.img.shape[1], self.img.shape[0]
         # Convert to grayscale and extract center block
         self.img = cv2.cvtColor(self.img, cv2.COLOR_BGR2GRAY)
-        self.img_center_block = self.get_center_block()
+        image_name = os.path.basename(image_path_to_detect)
+        if rough_center is None and image_name in self.center_prior_dict:
+            rough_center = self.center_prior_dict[image_name]
+        self.img_center_block = self.get_search_block(rough_center)
 
         # Calculate score with different window size
         points_with_max_score = []
@@ -90,18 +118,29 @@ class ProloculusDetector:
         max_score_point = points_with_max_score[max_score_index]["points"][0]
         diameter = sizes[max_score_index]
 
-        x = max_score_point[0] + self.block_width * (self.block_num // 2)
-        y = max_score_point[1] + self.block_height * (self.block_num // 2)
+        x = max_score_point[0] + self.block_origin_x
+        y = max_score_point[1] + self.block_origin_y
         return [x, y, diameter]
 
-    def get_center_block(self):
+    def get_search_block(self, rough_center: tuple[int, int] | None = None):
         self.block_height = self.height // self.block_num
         self.block_width = self.width // self.block_num
 
-        x_start = (self.block_num // 2) * self.block_width
-        x_end = (self.block_num // 2 + 1) * self.block_width
-        y_start = (self.block_num // 2) * self.block_height
-        y_end = (self.block_num // 2 + 1) * self.block_height
+        if rough_center is None:
+            center_x, center_y = self.width // 2, self.height // 2
+        else:
+            center_x = int(np.clip(rough_center[0], 0, self.width - 1))
+            center_y = int(np.clip(rough_center[1], 0, self.height - 1))
+
+        max_x_start = max(self.width - self.block_width, 0)
+        max_y_start = max(self.height - self.block_height, 0)
+        x_start = int(np.clip(center_x - self.block_width // 2, 0, max_x_start))
+        y_start = int(np.clip(center_y - self.block_height // 2, 0, max_y_start))
+        x_end = x_start + self.block_width
+        y_end = y_start + self.block_height
+
+        self.block_origin_x = x_start
+        self.block_origin_y = y_start
 
         center_block = self.img[y_start:y_end, x_start:x_end]
         return center_block

--- a/stage3/recognize.py
+++ b/stage3/recognize.py
@@ -10,8 +10,13 @@ from stage3.initial_chamber import ProloculusDetector
 from stage3.utils import calculate_angle, resize_img
 from stage3.volution_counter import VolutionCounter
 
+"""
+快捷方法：直接在这里设置默认的center_prior_jsonl
+如果要支持args传入，则需要修改generate_dataset.py中的recognize_feature
+"""
 
-def recognize_feature(img_path: str) -> tuple:
+
+def recognize_feature(img_path: str, center_prior_jsonl: str | None = None) -> tuple:
     img_rgb = cv2.imread(img_path)
     orig_h, orig_w = img_rgb.shape[:2]
     # Opening preprocess and resize
@@ -22,7 +27,7 @@ def recognize_feature(img_path: str) -> tuple:
     h, w = img_rgb.shape[:2]
 
     # Detect initial chamber
-    proloculus_detector = ProloculusDetector()
+    proloculus_detector = ProloculusDetector(center_prior_jsonl=center_prior_jsonl)
     initial_chamber = proloculus_detector.detect_initial_chamber(img_path, threshold=0.25)
     if initial_chamber is None:  # retry with lower threshold
         initial_chamber = proloculus_detector.detect_initial_chamber(img_path, threshold=0.1)


### PR DESCRIPTION
1. 传入的初房位置jsonl格式：`{"<image_name>": {"x": 111, "y": 222}}`
快捷的测试方法是在`stage3/recognize.py`的recognize_feature直接指定默认路径；

2. 直接评测专家工具效果的脚本是`eval/eval_vis_tools.py`，提供三个参数：数据json文件，图片目录和输出路径
  - 数据json文件格式是地科提供的原始数据文件格式，如<img width="935" height="875" alt="image" src="https://github.com/user-attachments/assets/2b056c41-8c35-4c09-b2bb-b8b089af62d1" />
  - 生成的文件格式和llm抽取后的json一致，可以直接用于eval